### PR TITLE
fix: add variable for amp role creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ When you set up NAC the VPC endpoint URL will not have a route to the public URL
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region | `string` | `"us-east-1"` | no |
 | <a name="input_aws_route53_zone_tags"></a> [aws\_route53\_zone\_tags](#input\_aws\_route53\_zone\_tags) | value of the private hosted zone tags | `map(string)` | `{}` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
+| <a name="input_create_amp_iam_role"></a> [create\_amp\_iam\_role](#input\_create\_amp\_iam\_role) | Whether to create the AMP IAM role or not. 1 per account is needed. | `bool` | `true` | no |
 | <a name="input_create_dashboard_folder"></a> [create\_dashboard\_folder](#input\_create\_dashboard\_folder) | Boolean flag to enable Amazon Managed Grafana folder and dashboards | `bool` | `true` | no |
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Determines whether a an IAM role is created or to use an existing IAM role | `bool` | `true` | no |
 | <a name="input_create_prometheus_data_source"></a> [create\_prometheus\_data\_source](#input\_create\_prometheus\_data\_source) | Boolean flag to enable Amazon Managed Grafana datasource | `bool` | `true` | no |

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -21,7 +21,8 @@ resource "aws_prometheus_alert_manager_definition" "this" {
 }
 
 resource "aws_iam_role" "amp_iam_role" {
-  name = "amp_iam_role"
+  count = var.create_amp_iam_role ? 1 : 0
+  name  = "amp_iam_role"
 
   assume_role_policy = <<EOF
 {
@@ -49,8 +50,9 @@ EOF
 # https://docs.aws.amazon.com/prometheus/latest/userguide/set-up-irsa.html#set-up-irsa-ingest
 #tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "amp_role_policy" {
-  name = "amp_role_policy"
-  role = aws_iam_role.amp_iam_role.id
+  count = var.create_amp_iam_role ? 1 : 0
+  name  = "amp_role_policy"
+  role  = aws_iam_role.amp_iam_role.id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{

--- a/variables.tf
+++ b/variables.tf
@@ -280,6 +280,12 @@ variable "s3_website_endpoint_zone_ids" {
   }
 }
 
+variable "create_amp_iam_role" {
+  type        = bool
+  default     = true
+  description = "Whether to create the AMP IAM role or not. 1 per account is needed."
+}
+
 locals {
   s3_website_endpoint_zone_id = var.s3_website_endpoint_zone_ids[var.aws_region]
 }


### PR DESCRIPTION
Fixes issue where AMP is being deployed a second time within an account with the IAM role already existing.