### PR TITLE
feat: permissions for alertmanger datasource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,6 +129,19 @@ resource "aws_iam_role_policy" "grafana_xray_policy" {
           "ec2:DescribeRegions"
         ],
         "Resource" : "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "aps:ListRules",
+          "aps:ListAlertManagerSilences",
+          "aps:ListAlertManagerAlerts",
+          "aps:GetAlertManagerStatus",
+          "aps:ListAlertManagerAlertGroups",
+          "aps:PutAlertManagerSilences",
+          "aps:DeleteAlertManagerSilence"
+        ],
+        "Resource": "*"
       }
     ]
   })

--- a/main.tf
+++ b/main.tf
@@ -131,8 +131,8 @@ resource "aws_iam_role_policy" "grafana_xray_policy" {
         "Resource" : "*"
       },
       {
-        "Effect": "Allow",
-        "Action": [
+        "Effect" : "Allow",
+        "Action" : [
           "aps:ListRules",
           "aps:ListAlertManagerSilences",
           "aps:ListAlertManagerAlerts",
@@ -141,7 +141,7 @@ resource "aws_iam_role_policy" "grafana_xray_policy" {
           "aps:PutAlertManagerSilences",
           "aps:DeleteAlertManagerSilence"
         ],
-        "Resource": "*"
+        "Resource" : "*"
       }
     ]
   })


### PR DESCRIPTION
Add permissions needed for Grafana to use the alertmanager datasource