### PR TITLE
fix: add env suffice to resource names

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ When you set up NAC the VPC endpoint URL will not have a route to the public URL
 | <a name="input_amp_workspace_id"></a> [amp\_workspace\_id](#input\_amp\_workspace\_id) | If 'amp\_create\_workspace' is set to 'false' then a workspace has to be supplied. | `string` | `""` | no |
 | <a name="input_amp_ws_alias"></a> [amp\_ws\_alias](#input\_amp\_ws\_alias) | The alias of the AMP workspace | `string` | `"observability-amp-workspace"` | no |
 | <a name="input_authentication_providers"></a> [authentication\_providers](#input\_authentication\_providers) | List containing the methods used to authenticate. | `list(any)` | n/a | yes |
+| <a name="input_aws_cloudwatch_log_group_retention_in_days"></a> [aws\_cloudwatch\_log\_group\_retention\_in\_days](#input\_aws\_cloudwatch\_log\_group\_retention\_in\_days) | The retention period of the CloudWatch log group in days | `number` | `60` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region | `string` | `"us-east-1"` | no |
 | <a name="input_aws_route53_zone_tags"></a> [aws\_route53\_zone\_tags](#input\_aws\_route53\_zone\_tags) | value of the private hosted zone tags | `map(string)` | `{}` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,9 @@ module "managed_grafana" {
     unifiedAlerting = {
       enabled = true
     }
+    plugins = {
+      pluginAdminEnabled = false
+    }
   })
 
   # Workspace IAM role
@@ -57,8 +60,8 @@ module "managed_grafana" {
 resource "aws_iam_role_policy" "grafana_xray_policy" {
   depends_on = [module.managed_grafana]
 
-  name = "GrafanaXrayDatasourcePolicy"
-  role = module.managed_grafana.workspace_iam_role_arn
+  name = "GrafanaXrayDatasourcePolicy-${var.environment}"
+  role = module.managed_grafana.workspace_iam_role_name
 
   # Terraform's "jsonencode" function converts a
   # Terraform expression result to valid JSON syntax.

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -1,11 +1,12 @@
 #tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "amp_log_group" {
-  name_prefix = "/o11y/amp/"
+  name_prefix = "/o11y/amp/${var.environment}/"
+  retention_in_days = var.aws_cloudwatch_log_group_retention_in_days
 }
 
 resource "aws_iam_role" "amp_iam_role" {
   count = var.create_amp_iam_role ? 1 : 0
-  name  = "amp_iam_role"
+  name  = "amp_iam_role_${var.environment}"
 
   assume_role_policy = <<EOF
 {
@@ -34,7 +35,7 @@ EOF
 #tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "amp_role_policy" {
   count = var.create_amp_iam_role ? 1 : 0
-  name  = "amp_role_policy"
+  name  = "amp_role_policy_${var.environment}"
   role  = aws_iam_role.amp_iam_role[0].id
   policy = jsonencode({
     Version = "2012-10-17"

--- a/variables.tf
+++ b/variables.tf
@@ -281,3 +281,9 @@ variable "create_redirect" {
   default     = false
   description = "Whether to create a redirect from the S3 bucket to the workspace or not"
 }
+
+variable "aws_cloudwatch_log_group_retention_in_days" {
+  description = "The retention period of the CloudWatch log group in days"
+  type        = number
+  default     = 60
+}


### PR DESCRIPTION
- Added environment as a suffix to certain resources which avoids a name collision when applied twice in the same AWS account/region. 

- Added an input variable for cloudwatch log rentention. 

- Disabled pluginAdmin for grafana module to avoid noisy plans since the setting is configured by default after resource creation.